### PR TITLE
Add GitHub Actions workflow to build and publish Docker image

### DIFF
--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -1,0 +1,51 @@
+name: Build and publish a Docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64, linux/arm/v7, linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   bmw-bridge:
-    image: ghcr.io/oemich/bmw-mqtt-bridge:latest
+    image: ghcr.io/dj0abr/bmw-mqtt-bridge:latest
     environment:
       - XDG_STATE_HOME=/app/state          # Parent; Bridge nutzt /app/state/bmw-mqtt-bridge
       - LOCAL_HOST=host.docker.internal    # MQTT läuft i.d.R. auf dem Host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   bmw-bridge:
-    build: .
+    image: ghcr.io/oemich/bmw-mqtt-bridge:latest
     environment:
       - XDG_STATE_HOME=/app/state          # Parent; Bridge nutzt /app/state/bmw-mqtt-bridge
       - LOCAL_HOST=host.docker.internal    # MQTT läuft i.d.R. auf dem Host

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,3 +33,29 @@ docker compose logs -f bmw-bridge
 ```
 
 The bridge will now automatically stream BMW CarData to your local MQTT broker.
+
+## Build and run your own Docker image
+
+If you want to build the docker image yourself (e.g. to use the latest source code), run:
+
+```bash
+# Build the Docker image with a custom tag
+docker build -t bmw-mqtt-bridge:custom .
+
+# Authenticate with BMW (creates .env automatically)
+docker run -it --rm \
+  -v ~/.local/state/bmw-mqtt-bridge:/app/state \
+  -e TZ=Europe/Berlin \
+  bmw-mqtt-bridge:custom ./bmw_flow.sh
+
+# Start the bridge in detached mode
+docker run -d \
+    --name bmw-bridge \
+    -e XDG_STATE_HOME=/app/state \
+    -e LOCAL_HOST=host.docker.internal \
+    -e LOCAL_PORT=1883 \
+    -e LOCAL_PREFIX=bmw/ \
+    -v ~/.local/state/bmw-mqtt-bridge:/app/state/bmw-mqtt \
+    bmw-mqtt-bridge:custom \
+    --restart unless-stopped
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,9 +14,6 @@ so host and container share the same configuration and tokens.
 You can freely switch between **Docker** and the **classic bare-metal** version without re-authenticating.
 
 ```bash
-# Build container
-docker compose build --no-cache
-
 # Authenticate with BMW (creates .env automatically)
 docker compose run --rm -it bmw-bridge ./bmw_flow.sh
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -44,9 +44,9 @@ docker build -t bmw-mqtt-bridge:custom .
 
 # Authenticate with BMW (creates .env automatically)
 docker run -it --rm \
-  -v ~/.local/state/bmw-mqtt-bridge:/app/state \
-  -e TZ=Europe/Berlin \
-  bmw-mqtt-bridge:custom ./bmw_flow.sh
+    -v ~/.local/state/bmw-mqtt-bridge:/app/state \
+    -e TZ=Europe/Berlin \
+    bmw-mqtt-bridge:custom ./bmw_flow.sh
 
 # Start the bridge in detached mode
 docker run -d \

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,29 +33,3 @@ docker compose logs -f bmw-bridge
 ```
 
 The bridge will now automatically stream BMW CarData to your local MQTT broker.
-
-## Build and run your own Docker image
-
-If you want to build the docker image yourself (e.g. to use the latest source code), run:
-
-```bash
-# Build the Docker image with a custom tag
-docker build -t bmw-mqtt-bridge:custom .
-
-# Authenticate with BMW (creates .env automatically)
-docker run -it --rm \
-    -v ~/.local/state/bmw-mqtt-bridge:/app/state \
-    -e TZ=Europe/Berlin \
-    bmw-mqtt-bridge:custom ./bmw_flow.sh
-
-# Start the bridge in detached mode
-docker run -d \
-    --name bmw-bridge \
-    -e XDG_STATE_HOME=/app/state \
-    -e LOCAL_HOST=host.docker.internal \
-    -e LOCAL_PORT=1883 \
-    -e LOCAL_PREFIX=bmw/ \
-    -v ~/.local/state/bmw-mqtt-bridge:/app/state/bmw-mqtt \
-    bmw-mqtt-bridge:custom \
-    --restart unless-stopped
-```


### PR DESCRIPTION
This PullRequest introduces a GitHub Workflow to build and publish the docker image automatically. The image will be published to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) which is directly linked with the repository itself.

This is the most simples mode by creating a new image with tag __latest__ for every push happening to the __main__ branch. If you would prefer e.g. creating in some point in time releases with [Semantic Versioning](https://semver.org/) the workflow could be easily be adapted to react only on releases creation and include the semantic versioning in the image tag. But for now I think __latest__ is fine.

Supported platforms are:
- linux/amd64 
- linux/arm64
- linux/arm/v7

The prebuild container image simplifies even more the usage of the __bmw-mqtt-bridge__. Some of the prerequisites for the docker usage are resolved. User can use the prebuild image and benefit from automatic update to newer versions of the image with e.g. [Watchtower](https://github.com/containrrr/watchtower) or other automated Docker container base image updates.